### PR TITLE
Possible solution for edenhill#425

### DIFF
--- a/win32/win32_config.h
+++ b/win32/win32_config.h
@@ -1,3 +1,39 @@
 #pragma once
 
 #define KCAT_VERSION "1.8.0" /* Manually updated */
+
+/*
+    From syslog.h - to fix "E0020: identifier "LOG_DEBUG" is undefined"
+    Added "ifndef" directives for the case where someone might use a third party syslog client, e.g. https://github.com/asankah/syslog-win32
+*/
+#ifndef	LOG_EMERG
+#define	LOG_EMERG	0	/* system is unusable */
+#endif
+#ifndef	LOG_ALERT
+#define	LOG_ALERT	1	/* action must be taken immediately */
+#endif
+#ifndef	LOG_CRIT
+#define	LOG_CRIT	2	/* critical conditions */
+#endif
+#ifndef	LOG_ERR
+#define	LOG_ERR		3	/* error conditions */
+#endif
+#ifndef	LOG_WARNING
+#define	LOG_WARNING	4	/* warning conditions */
+#endif
+#ifndef	LOG_NOTICE
+#define	LOG_NOTICE	5	/* normal but significant condition */
+#endif
+#ifndef	LOG_INFO
+#define	LOG_INFO	6	/* informational */
+#endif
+#ifndef	LOG_DEBUG
+#define	LOG_DEBUG	7	/* debug-level messages */
+#endif
+
+/* check librdkafka version and define ENABLE_KAFKACONSUMER */
+#if RD_KAFKA_VERSION >= 0x00090100
+#define ENABLE_KAFKACONSUMER 1
+#else
+#define ENABLE_KAFKACONSUMER 0
+#endif


### PR DESCRIPTION
In `win32\win32_config.h`:

- added version check for `librdkafka`;
- if the version >= `0x00090100`, sets `ENABLE_KAFKACONSUMER` to 1;
- otherwise sets `ENABLE_KAFKACONSUMER` to 0.
- also added definitions for `LOG_EMERG`, `LOG_ALERT`, `LOG_CRIT`, `LOG_ERR`, `LOG_WARNING`, `LOG_NOTICE`, `LOG_INFO` and `LOG_DEBUG` from [syslog.h](https://github.com/openbsd/src/blob/master/sys/sys/syslog.h), ifndef